### PR TITLE
Fixed build

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:tsc": "tsc",
     "lint:prettier": "prettier --check '**/*.{json,md}'",
     "lint:stylelint": "stylelint ./src/**/*.css",
-    "build": "microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --external react,react-dom",
+    "build": "microbundle --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react",
     "dev": "npm run build watch"
   },
   "peerDependencies": {


### PR DESCRIPTION
- removed from build command `external` flag.

According to the `microbundle` docs:
```
--external         Specify external dependencies, or 'none' (default peerDependencies and dependencies in package.json)
```

It included only `peerDependencies` and it results in large bundle size. Now, it specifies `peerDependencies` and `dependencies` by default.